### PR TITLE
Read input data files by line

### DIFF
--- a/lib/formulary/qhp_importer.rb
+++ b/lib/formulary/qhp_importer.rb
@@ -19,8 +19,10 @@ module Formulary
         puts "Reading #{filenames.length} file(s) from #{url}"
 
         filenames.each do |filename|
-          qhp_raw_data = File.read(filename)
-          qhp_json.concat(JSON.parse(qhp_raw_data, symbolize_names: true))
+          qhp_raw_data = File.read(filename).split("\n")
+          qhp_raw_data.each { |line|
+            qhp_json.push(JSON.parse(line, symbolize_names: true))
+          }
           repo.import(qhp_json)
         end
       end


### PR DESCRIPTION
We currently export Snowflake data to S3 using a COPY INTO function, which transforms formulary/plan rows to JSON objects and separates them with a newline character. qhp_importer.rb previously expected an array of JSON objects for each data file read. This will adjust the plans/formulary data importer (qhp_importer.rb) to read the input files by line and parse the JSON objects individually. 

I also weighed creating a single file with a large array of JSON objects with the COPY INTO Snowflake function, but the granularity of reading the objects by line gives us some flexibility with error reporting + performance improvements in the future.

### How did I test?
I successfully parsed the JSON files output by the associated DAG