### PR TITLE
Update nokogiri to recent version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,20 +19,21 @@ GEM
       nokogiri (>= 1.8.2)
     git (1.5.0)
     hashdiff (0.4.0)
-    httparty (0.17.0)
+    httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
     method_source (0.9.2)
-    mime-types (3.2.2)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
-    mini_portile2 (2.4.0)
+    mime-types-data (3.2022.0105)
+    mini_portile2 (2.6.1)
     multi_xml (0.6.0)
-    nokogiri (1.10.3)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     parallel (1.17.0)
     parser (2.6.3.0)
       ast (~> 2.4.0)
@@ -40,6 +41,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.1.0)
+    racc (1.6.0)
     rainbow (3.0.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -77,6 +79,8 @@ DEPENDENCIES
   fhir_models
   git
   httparty
+  mime-types
+  nokogiri (= 1.12.5)
   pry
   rspec
   rubocop
@@ -84,4 +88,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.0.1
+   2.3.22


### PR DESCRIPTION
Update nokogiri to a recent version so that we can continue to install it